### PR TITLE
Using Yettings in non default RAILS_ENV

### DIFF
--- a/lib/yettings.rb
+++ b/lib/yettings.rb
@@ -26,7 +26,7 @@ module Yettings
       klass = Object.const_set(klass_name,Class.new)
       hash.each do |key,value|
         klass.define_singleton_method(key){ value }
-      end
+      end unless hash.nil?
       klass.class_eval do
         def self.method_missing(method_id,*args)
           raise UndefinedYetting, "#{method_id} is not defined in #{self.to_s}"


### PR DESCRIPTION
This change allows you to use Yettings in a custom Rails environment without having to add the new Rails env to each Yettings file.

For example you will be able to run the following Rake task

rake db:migrate RAILS_ENV=myenv

without having to modify any Yettings file.

Otherwise you would need to add the following to every Yettings yml file in order to get the command above to work:
myenv:
  <<: *defaults

What do you think?
Regards
